### PR TITLE
Feat/7 slider

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -40,7 +40,7 @@ export default function Banner() {
       nodeRef={nodeRef}
     >
       <div ref={nodeRef} className="banner-responsive relative">
-        <div className="banner-responsive fixed z-0 w-full">
+        <div className="banner-responsive w-full">
           <img
             className="banner-responsive w-full object-cover"
             src={`${BASE_URL_ORIGIN}${media.backdrop_path}`}

--- a/src/components/SliderSection.tsx
+++ b/src/components/SliderSection.tsx
@@ -8,11 +8,7 @@ interface SliderSectionProps {
   type: string;
 }
 
-export default function SliderSection({
-  data,
-  title,
-  type,
-}: SliderSectionProps) {
+export default function SliderSection({ data, title }: SliderSectionProps) {
   const [currentPage, setCurrentPage] = useState(0);
   const [cardsPerPage, setCardsPerPage] = useState(7);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -39,25 +35,12 @@ export default function SliderSection({
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const slideTo = (page: number) => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const containerWidth = container.offsetWidth;
-    const cardWidth = containerWidth / data.length;
-
-    const moveX = cardWidth * cardsPerPage * page;
-    container.style.transform = `translateX(-${moveX}px)`;
-
-    setCurrentPage(page);
-  };
-
   const handleNext = () => {
-    if (currentPage < totalPages - 1) slideTo(currentPage + 1);
+    if (currentPage < totalPages - 1) setCurrentPage(prev => prev + 1);
   };
 
   const handlePrev = () => {
-    if (currentPage > 0) slideTo(currentPage - 1);
+    if (currentPage > 0) setCurrentPage(prev => prev - 1);
   };
 
   return (
@@ -68,6 +51,7 @@ export default function SliderSection({
         className="ease flex transition-transform duration-1000"
         ref={containerRef}
         style={{
+          transform: `translateX(-${(100 / totalPages) * currentPage}%)`,
           width: `${(data.length / cardsPerPage) * 100}%`,
         }}
       >

--- a/src/components/SliderSection.tsx
+++ b/src/components/SliderSection.tsx
@@ -1,6 +1,7 @@
 import type { MediaItem } from '@/types';
+import useResizeSlider from '@/hooks/useResizeSlider';
 import MediaCard from '@/components/MediaCard';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 interface SliderSectionProps {
   data: MediaItem[];
@@ -9,31 +10,11 @@ interface SliderSectionProps {
 }
 
 export default function SliderSection({ data, title }: SliderSectionProps) {
-  const [currentPage, setCurrentPage] = useState(0);
-  const [cardsPerPage, setCardsPerPage] = useState(7);
+  const { currentPage, setCurrentPage, cardsPerPage } = useResizeSlider();
+
   const containerRef = useRef<HTMLDivElement>(null);
 
   const totalPages = Math.ceil(data.length / cardsPerPage);
-
-  useEffect(() => {
-    const handleResize = () => {
-      const width = window.innerWidth;
-
-      if (width < 480) setCardsPerPage(3);
-      else if (width < 600) setCardsPerPage(4);
-      else if (width < 768) setCardsPerPage(5);
-      else if (width < 1024) setCardsPerPage(6);
-      else setCardsPerPage(7);
-
-      setCurrentPage(0);
-    };
-
-    handleResize();
-
-    window.addEventListener('resize', handleResize);
-
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   const handleNext = () => {
     if (currentPage < totalPages - 1) setCurrentPage(prev => prev + 1);

--- a/src/components/SliderSection.tsx
+++ b/src/components/SliderSection.tsx
@@ -1,0 +1,104 @@
+import type { MediaItem } from '@/types';
+import MediaCard from '@/components/MediaCard';
+import { useEffect, useRef, useState } from 'react';
+
+interface SliderSectionProps {
+  data: MediaItem[];
+  title: string;
+  type: string;
+}
+
+export default function SliderSection({
+  data,
+  title,
+  type,
+}: SliderSectionProps) {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [cardsPerPage, setCardsPerPage] = useState(7);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const totalPages = Math.ceil(data.length / cardsPerPage);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const width = window.innerWidth;
+
+      if (width < 480) setCardsPerPage(3);
+      else if (width < 600) setCardsPerPage(4);
+      else if (width < 768) setCardsPerPage(5);
+      else if (width < 1024) setCardsPerPage(6);
+      else setCardsPerPage(7);
+
+      setCurrentPage(0);
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const slideTo = (page: number) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const containerWidth = container.offsetWidth;
+    const cardWidth = containerWidth / data.length;
+
+    const moveX = cardWidth * cardsPerPage * page;
+    container.style.transform = `translateX(-${moveX}px)`;
+
+    setCurrentPage(page);
+  };
+
+  const handleNext = () => {
+    if (currentPage < totalPages - 1) slideTo(currentPage + 1);
+  };
+
+  const handlePrev = () => {
+    if (currentPage > 0) slideTo(currentPage - 1);
+  };
+
+  return (
+    <div className="group relative mb-10 w-full overflow-hidden px-[5vw]">
+      <h3 className="mb-4">{title}</h3>
+
+      <div
+        className="ease flex transition-transform duration-1000"
+        ref={containerRef}
+        style={{
+          width: `${(data.length / cardsPerPage) * 100}%`,
+        }}
+      >
+        {data.map(el => (
+          <div
+            key={el.id}
+            style={{
+              flex: `0 0 ${100 / data.length}%`,
+              padding: '4px',
+            }}
+          >
+            <MediaCard title={el.title || ''} imgSrc={el.poster_path} />
+          </div>
+        ))}
+      </div>
+
+      <button
+        className="absolute left-0 top-[40px] z-10 h-[calc(100%-40px)] w-[5vw] rounded-r-sm bg-black/50 text-3xl text-transparent transition-all duration-200 ease-in-out hover:bg-black/80 hover:text-4xl hover:text-white group-hover:bg-black/80 group-hover:text-white"
+        onClick={handlePrev}
+        style={{ opacity: currentPage === 0 ? '0' : '1' }}
+      >
+        &lt;
+      </button>
+
+      <button
+        className="absolute right-0 top-[40px] z-10 h-[calc(100%-40px)] w-[5vw] rounded-l-sm bg-black/50 text-3xl text-transparent transition-all duration-200 ease-in-out hover:bg-black/80 hover:text-4xl hover:text-white group-hover:bg-black/80 group-hover:text-white"
+        onClick={handleNext}
+        style={{ opacity: currentPage === totalPages - 1 ? '0' : '1' }}
+      >
+        &gt;
+      </button>
+    </div>
+  );
+}

--- a/src/components/Sliders.tsx
+++ b/src/components/Sliders.tsx
@@ -1,0 +1,59 @@
+import type { MediaItem } from '@/types';
+import useFetch from '@/hooks/useFetch';
+import SliderSection from '@/components/SliderSection';
+
+type Movie = MediaItem;
+
+type FetchResponse = {
+  results: Movie[];
+};
+
+export default function Sliders() {
+  const { data: popularMovieData, loading: popularMovieLoading } =
+    useFetch<FetchResponse>(
+      'movie/popular?include_adult=false&language=ko&page=1',
+    );
+  const { data: onTheAirData, loading: onTheAirLoading } =
+    useFetch<FetchResponse>('tv/on_the_air?language=ko&page=1');
+  const { data: seriesUSData, loading: seriesUSLoading } =
+    useFetch<FetchResponse>(
+      'discover/tv?include_adult=false&include_null_first_air_dates=false&language=ko&page=1&sort_by=popularity.desc&with_origin_country=US',
+    );
+
+  const sliders = [
+    {
+      title: '인기 영화',
+      data: popularMovieData?.results || [],
+      loading: popularMovieLoading,
+      type: 'movie',
+    },
+    {
+      title: '매주 공개! 이건 꼭 봐야 해',
+      data: onTheAirData?.results || [],
+      loading: onTheAirLoading,
+      type: 'tv',
+    },
+    {
+      title: '미국 드라마',
+      data: seriesUSData?.results || [],
+      loading: seriesUSLoading,
+      type: 'tv',
+    },
+  ];
+
+  return (
+    <div className="w-full px-[5vw]">
+      {sliders.map(
+        (slider, idx) =>
+          !slider.loading && (
+            <SliderSection
+              key={idx}
+              title={slider.title}
+              data={slider.data}
+              type={slider.type}
+            />
+          ),
+      )}
+    </div>
+  );
+}

--- a/src/components/Sliders.tsx
+++ b/src/components/Sliders.tsx
@@ -42,7 +42,7 @@ export default function Sliders() {
   ];
 
   return (
-    <div className="w-full px-[5vw]">
+    <div className="w-full">
       {sliders.map(
         (slider, idx) =>
           !slider.loading && (

--- a/src/hooks/useResizeSlider.ts
+++ b/src/hooks/useResizeSlider.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+export default function useResizeSlider() {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [cardsPerPage, setCardsPerPage] = useState(7);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const width = window.innerWidth;
+
+      if (width < 480) setCardsPerPage(3);
+      else if (width < 600) setCardsPerPage(4);
+      else if (width < 768) setCardsPerPage(5);
+      else if (width < 1024) setCardsPerPage(6);
+      else setCardsPerPage(7);
+
+      setCurrentPage(0);
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return { currentPage, setCurrentPage, cardsPerPage };
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,11 @@
 import Banner from '@/components/Banner';
+import Sliders from '@/components/Sliders';
 
 export default function Home() {
   return (
     <>
       <Banner />
-      Home
+      <Sliders />
     </>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #7 

## 📝작업 내용

> 슬라이더 섹션 추가
- Sliders 컴포넌트 생성
  - API 응답을 sliders 배열로 구성, SliderSection으로 데이터 전달
  - Home 컴포넌트에서 Sliders 컴포넌트 추가
- SliderSection 컴포넌트 생성
  - props로 전달받은 데이터 목록을 슬라이더 형태로 렌더링
  - 반응형: 화면 너비에 따라 페이지당 카드 수 변경. useResizeSlider() 훅

## 스크린샷
![image](https://github.com/user-attachments/assets/8e080cc7-ea7d-4c6b-b9c9-fc5334941291)
