### PR TITLE
Feat/18 tv season

### DIFF
--- a/src/components/detailModal/DetailModal.tsx
+++ b/src/components/detailModal/DetailModal.tsx
@@ -6,6 +6,7 @@ import { BASE_URL_ORIGIN } from '@/constants';
 import { parseMediaInfo } from '@/utils/parseMediaInfo';
 import Button from '@/components/common/Button';
 import Recommendation from '@/components/detailModal/Recommendation';
+import Season from '@/components/detailModal/Season';
 
 interface Props {
   type: string;
@@ -23,8 +24,6 @@ export default function DetailModal({ type, id, onClose }: Props) {
   const { data: recommendationData } = useFetch<RecommendationsResponse>(
     `${type}/${id}/recommendations?language=ko`,
   );
-
-  console.log(recommendationData);
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -68,7 +67,7 @@ export default function DetailModal({ type, id, onClose }: Props) {
         </div>
 
         {/* 본문 */}
-        <div className="flex flex-col gap-6 px-10 pt-2">
+        <div className="flex flex-col gap-10 px-10 pt-2">
           <div className="flex flex-col gap-2">
             <p className="text-gray-200">
               {year}
@@ -89,6 +88,10 @@ export default function DetailModal({ type, id, onClose }: Props) {
             {data.tagline && <p className="text-lg italic">"{data.tagline}"</p>}
             <p>{data.overview}</p>
           </div>
+
+          {type === 'tv' ? (
+            <Season id={data.id} seriesLength={data.seasons.length} />
+          ) : null}
 
           {recommendationData?.results?.length ? (
             <Recommendation data={recommendationData} />

--- a/src/components/detailModal/DetailModal.tsx
+++ b/src/components/detailModal/DetailModal.tsx
@@ -34,7 +34,7 @@ export default function DetailModal({ type, id, onClose }: Props) {
 
   if (loading || !data) return null;
 
-  const { title, year, runtimeOrSeasons } = parseMediaInfo(data, type);
+  const { title, year, seasons, runtime } = parseMediaInfo(data, type);
 
   return (
     // 모달 배경
@@ -72,7 +72,7 @@ export default function DetailModal({ type, id, onClose }: Props) {
             <p className="text-gray-200">
               {year}
               <span className="mx-2">·</span>
-              {runtimeOrSeasons}
+              {seasons || runtime}
             </p>
             <div className="mb-5 flex items-center gap-2">
               <p>장르:</p>

--- a/src/components/detailModal/DetailModal.tsx
+++ b/src/components/detailModal/DetailModal.tsx
@@ -40,7 +40,7 @@ export default function DetailModal({ type, id, onClose }: Props) {
     // 모달 배경
     <div className="fixed left-0 top-0 z-[1000] h-full w-full overflow-y-scroll bg-black/80 px-5 py-10">
       {/* 모달 */}
-      <div className="relative m-auto max-w-4xl overflow-hidden rounded-md bg-stone-900 pb-5">
+      <div className="relative m-auto max-w-4xl overflow-hidden rounded-md bg-stone-900 pb-10">
         {/* 상단 백드랍 이미지 및 제목, 닫기 버튼 */}
         <div className="relative h-[440px] w-full">
           <img

--- a/src/components/detailModal/Recommendation.tsx
+++ b/src/components/detailModal/Recommendation.tsx
@@ -2,9 +2,9 @@ import MediaCard from '../MediaCard';
 
 export default function Recommendation({ data }: { data: any }) {
   return (
-    <>
-      <h2 className="mt-10 text-xl">함께 시청된 콘텐츠</h2>
-      <section className="grid grid-cols-[repeat(4,1fr)] gap-6">
+    <section>
+      <h2 className="mb-6 text-xl">함께 시청된 콘텐츠</h2>
+      <div className="grid grid-cols-[repeat(4,1fr)] gap-6">
         {data?.results.map((el: any) => (
           <MediaCard
             key={el.id}
@@ -13,7 +13,7 @@ export default function Recommendation({ data }: { data: any }) {
             path={`?type=${el.media_type}&id=${el.id}`}
           />
         ))}
-      </section>
-    </>
+      </div>
+    </section>
   );
 }

--- a/src/components/detailModal/Season.tsx
+++ b/src/components/detailModal/Season.tsx
@@ -26,37 +26,47 @@ export default function Season({ id, seriesLength }: Props) {
 
   return (
     <section>
-      <h2 className="mb-6 text-xl">회차</h2>
+      <div className="flex justify-between">
+        <h2 className="text-xl">회차</h2>
 
-      <select
-        value={selectedSeason}
-        onChange={e => setSelectedSeason(Number(e.target.value))}
-        className="ex mb-6 rounded border px-2 py-1 text-black"
-      >
-        {Array.from({ length: seriesLength }, (_, i) => (
-          <option key={i + 1} value={i + 1}>
-            시즌 {i + 1}
-          </option>
-        ))}
-      </select>
+        <select
+          id="season"
+          name="season"
+          value={selectedSeason}
+          onChange={e => setSelectedSeason(Number(e.target.value))}
+          className="rounded border border-stone-500 bg-stone-800 px-2 py-2 outline-none"
+        >
+          {Array.from({ length: seriesLength }, (_, i) => (
+            <option key={i + 1} value={i + 1}>
+              시즌 {i + 1}
+            </option>
+          ))}
+        </select>
+      </div>
 
-      {seasonData && (
-        <div>
-          <p>{seasonData.name}</p>
-          {seasonData.episodes?.map(episode => {
+      {seasonData && !loading && (
+        <div className="divide-y divide-gray-600">
+          {seasonData.episodes?.map((episode, index) => {
             const { runtime } = parseMediaInfo(episode, 'tv');
 
             return (
-              <div key={episode.id} className="flex">
+              <div
+                key={episode.id}
+                className="mb-2 flex items-center gap-4 p-8"
+              >
+                <p className="text-xl text-gray-300">{index + 1}</p>
                 <img
                   src={`${BASE_URL}${episode.still_path}`}
                   alt={episode.name}
+                  className="w-[25%]"
                 />
-                <div>
-                  <p>{episode.name}</p>
-                  <p>{episode.air_date}</p>
-                  <p>{runtime}</p>
-                  <p>{episode.overview}</p>
+                <div className="flex w-full flex-col gap-2">
+                  <p className="font-semibold">{episode.name}</p>
+                  <div className="flex justify-between text-sm text-gray-300">
+                    <p>{episode.air_date}</p>
+                    <p>{runtime}</p>
+                  </div>
+                  <p className="text-sm text-gray-100">{episode.overview}</p>
                 </div>
               </div>
             );

--- a/src/components/detailModal/Season.tsx
+++ b/src/components/detailModal/Season.tsx
@@ -52,7 +52,7 @@ export default function Season({ id, seriesLength }: Props) {
             return (
               <div
                 key={episode.id}
-                className="mb-2 flex items-center gap-4 p-8"
+                className="flex cursor-pointer items-center gap-4 p-8 hover:bg-stone-800"
               >
                 <p className="text-xl text-gray-300">{index + 1}</p>
                 <img

--- a/src/components/detailModal/Season.tsx
+++ b/src/components/detailModal/Season.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  id: number;
+  seriesLength: number;
+}
+
+export default function Season({ id, seriesLength }: Props) {
+  return (
+    <section>
+      <h2 className="mb-6 text-xl">회차</h2>
+      <p>id: {id}</p>
+      <p>seriesLength: {seriesLength}</p>
+    </section>
+  );
+}

--- a/src/components/detailModal/Season.tsx
+++ b/src/components/detailModal/Season.tsx
@@ -1,14 +1,51 @@
+import { BASE_URL } from '@/constants';
+import useFetch from '@/hooks/useFetch';
+import type { SeasonItem } from '@/types';
+import { parseMediaInfo } from '@/utils/parseMediaInfo';
+
 interface Props {
   id: number;
   seriesLength: number;
 }
 
 export default function Season({ id, seriesLength }: Props) {
+  const seasonResults = Array.from({ length: seriesLength }, (_, i) =>
+    useFetch<SeasonItem>(`/tv/${id}/season/${i + 1}?language=ko`),
+  );
+
+  console.log(seasonResults);
+
   return (
     <section>
       <h2 className="mb-6 text-xl">회차</h2>
-      <p>id: {id}</p>
-      <p>seriesLength: {seriesLength}</p>
+      {seasonResults?.map(
+        season =>
+          season.data && (
+            // 시즌
+            <div key={season.data.id}>
+              <p>{season.data.name}</p>
+              {/* 에피소드 */}
+              {season.data.episodes?.map(episode => {
+                const { runtime } = parseMediaInfo(episode, 'tv');
+
+                return (
+                  <div key={episode.id} className="flex">
+                    <img
+                      src={`${BASE_URL}${episode.still_path}`}
+                      alt={episode.name}
+                    />
+                    <div>
+                      <p>{episode.name}</p>
+                      <p>{episode.air_date}</p>
+                      <p>{runtime}</p>
+                      <p>{episode.overview}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ),
+      )}
     </section>
   );
 }

--- a/src/components/detailModal/Season.tsx
+++ b/src/components/detailModal/Season.tsx
@@ -2,6 +2,7 @@ import { BASE_URL } from '@/constants';
 import useFetch from '@/hooks/useFetch';
 import type { SeasonItem } from '@/types';
 import { parseMediaInfo } from '@/utils/parseMediaInfo';
+import { useEffect, useState } from 'react';
 
 interface Props {
   id: number;
@@ -9,42 +10,58 @@ interface Props {
 }
 
 export default function Season({ id, seriesLength }: Props) {
-  const seasonResults = Array.from({ length: seriesLength }, (_, i) =>
-    useFetch<SeasonItem>(`/tv/${id}/season/${i + 1}?language=ko`),
+  const [selectedSeason, setSelectedSeason] = useState<number>(1);
+  const [seasonData, setSeasonData] = useState<SeasonItem | null>(null);
+
+  const { data, loading } = useFetch<SeasonItem>(
+    `/tv/${id}/season/${selectedSeason}?language=ko`,
   );
 
-  console.log(seasonResults);
+  useEffect(() => {
+    if (data) {
+      setSeasonData(data);
+      console.log(data);
+    }
+  }, [data]);
 
   return (
     <section>
       <h2 className="mb-6 text-xl">회차</h2>
-      {seasonResults?.map(
-        season =>
-          season.data && (
-            // 시즌
-            <div key={season.data.id}>
-              <p>{season.data.name}</p>
-              {/* 에피소드 */}
-              {season.data.episodes?.map(episode => {
-                const { runtime } = parseMediaInfo(episode, 'tv');
 
-                return (
-                  <div key={episode.id} className="flex">
-                    <img
-                      src={`${BASE_URL}${episode.still_path}`}
-                      alt={episode.name}
-                    />
-                    <div>
-                      <p>{episode.name}</p>
-                      <p>{episode.air_date}</p>
-                      <p>{runtime}</p>
-                      <p>{episode.overview}</p>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ),
+      <select
+        value={selectedSeason}
+        onChange={e => setSelectedSeason(Number(e.target.value))}
+        className="ex mb-6 rounded border px-2 py-1 text-black"
+      >
+        {Array.from({ length: seriesLength }, (_, i) => (
+          <option key={i + 1} value={i + 1}>
+            시즌 {i + 1}
+          </option>
+        ))}
+      </select>
+
+      {seasonData && (
+        <div>
+          <p>{seasonData.name}</p>
+          {seasonData.episodes?.map(episode => {
+            const { runtime } = parseMediaInfo(episode, 'tv');
+
+            return (
+              <div key={episode.id} className="flex">
+                <img
+                  src={`${BASE_URL}${episode.still_path}`}
+                  alt={episode.name}
+                />
+                <div>
+                  <p>{episode.name}</p>
+                  <p>{episode.air_date}</p>
+                  <p>{runtime}</p>
+                  <p>{episode.overview}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       )}
     </section>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -81,7 +81,6 @@ audio,
 video {
   margin: 0;
   padding: 0;
-  border: 0;
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,4 +21,5 @@ export interface MediaItem {
   genres: Genre[];
   runtime: string;
   number_of_seasons: string;
+  seasons: any;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,19 @@ export interface MediaItem {
   number_of_seasons: string;
   seasons: any;
 }
+
+export interface Episode {
+  id: number;
+  air_date: string;
+  episode_number: number;
+  name: string;
+  overview: string;
+  still_path: string;
+  runtime: number;
+}
+
+export interface SeasonItem {
+  id: number;
+  name: string;
+  episodes: Episode[];
+}

--- a/src/utils/parseMediaInfo.ts
+++ b/src/utils/parseMediaInfo.ts
@@ -20,7 +20,7 @@ export function parseMediaInfo(media: any, media_type: string) {
   const seasons =
     media_type === 'tv' ? `시즌 ${media.number_of_seasons}개` : null;
 
-  const runtime = `${Math.floor(media.runtime / 60)}시간 ${media.runtime % 60}분`;
+  const runtime = `${media.runtime >= 60 ? `${Math.floor(media.runtime / 60)}시간` : ''} ${media.runtime % 60}분`;
 
   return { title, originalTitle, year, overview, seasons, runtime };
 }

--- a/src/utils/parseMediaInfo.ts
+++ b/src/utils/parseMediaInfo.ts
@@ -17,10 +17,10 @@ export function parseMediaInfo(media: any, media_type: string) {
         : media.overview;
   }
 
-  const runtimeOrSeasons =
-    media_type === 'tv'
-      ? `시즌 ${media.number_of_seasons}개`
-      : `${Math.floor(media.runtime / 60)}시간 ${media.runtime % 60}분`;
+  const seasons =
+    media_type === 'tv' ? `시즌 ${media.number_of_seasons}개` : null;
 
-  return { title, originalTitle, year, overview, runtimeOrSeasons };
+  const runtime = `${Math.floor(media.runtime / 60)}시간 ${media.runtime % 60}분`;
+
+  return { title, originalTitle, year, overview, seasons, runtime };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18 

## 📝작업 내용

> 회차 섹션 추가
- Season 컴포넌트 생성: 회차 정보 표시
  - 회차 정보 api 호출
  - 드롭다운에서 시즌 선택 시 해당 시즌의 회차 표시
- 상세 모달에서  type이 'tv'일 때 Season 컴포넌트 렌더링

## 스크린샷 
![image](https://github.com/user-attachments/assets/e899f66e-f5f7-44e2-9a36-bf1893664c1e)
