### PR TITLE
Feat/27 favorites global state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Login from '@/pages/Login';
 import Register from '@/pages/Register';
 import Layout from '@/components/Layout';
 import Search from '@/pages/Search';
-// import Detail from './pages/Detail';
+import Mypage from './pages/mypage';
 
 function App() {
   return (
@@ -14,7 +14,7 @@ function App() {
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
           <Route path="search" element={<Search />} />
-          {/* <Route path="detail/:type/:id" element={<Detail />} /> */}
+          <Route path="mypage" element={<Mypage />} />
         </Route>
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />

--- a/src/components/UserIcon.tsx
+++ b/src/components/UserIcon.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { FaUserCircle } from 'react-icons/fa';
 import { useAuth } from '@/contexts/AuthContext';
 import useLogout from '@/hooks/auth/useLogout';
@@ -19,15 +20,14 @@ export default function UserIcon() {
       )}
 
       <div className="absolute right-0 top-0 hidden w-max group-hover:block">
-        <div className="mt-10 bg-[#000000c1] p-4 text-sm">
-          <button
-            type="button"
-            className="hover:underline"
-            onClick={handleLogout}
-          >
-            로그아웃
-          </button>
-        </div>
+        <ul className="mt-10 flex flex-col gap-4 bg-[#000000c1] p-4 text-sm">
+          <li className="hover:underline">
+            <Link to="/mypage">마이페이지</Link>
+          </li>
+          <li className="hover:underline">
+            <button onClick={handleLogout}>로그아웃</button>
+          </li>
+        </ul>
       </div>
     </div>
   );

--- a/src/components/detailModal/DetailModal.tsx
+++ b/src/components/detailModal/DetailModal.tsx
@@ -1,12 +1,14 @@
 import { useEffect } from 'react';
 import { IoMdCloseCircle } from 'react-icons/io';
-import type { MediaItem } from '@/types';
+import { IoAddCircleOutline, IoCheckmarkCircle } from 'react-icons/io5';
+import type { MediaItem, FavoriteItem } from '@/types';
 import useFetch from '@/hooks/useFetch';
 import { BASE_URL_ORIGIN } from '@/constants';
 import { parseMediaInfo } from '@/utils/parseMediaInfo';
 import Button from '@/components/common/Button';
 import Recommendation from '@/components/detailModal/Recommendation';
 import Season from '@/components/detailModal/Season';
+import { useFavorites } from '@/contexts/FavoriteContext';
 
 interface Props {
   type: string;
@@ -19,11 +21,19 @@ interface RecommendationsResponse {
 }
 
 export default function DetailModal({ type, id, onClose }: Props) {
+  const { isFavorite, toggleFavorite } = useFavorites();
   const { data, loading } = useFetch<MediaItem>(`${type}/${id}?language=ko`);
 
   const { data: recommendationData } = useFetch<RecommendationsResponse>(
     `${type}/${id}/recommendations?language=ko`,
   );
+
+  const item: FavoriteItem = {
+    id: Number(id),
+    media_type: type,
+    title: data?.title || data?.name || '',
+    poster_path: data?.poster_path || '',
+  };
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -55,13 +65,25 @@ export default function DetailModal({ type, id, onClose }: Props) {
               {title}
             </h1>
             <p className="mb-2">★ {data.vote_average.toFixed(1)}</p>
-            <Button variant="playSmall">
-              <span className="mr-4">▶</span>재생
-            </Button>
+            <div className="flex gap-2">
+              <Button variant="playSmall">
+                <span className="mr-4">▶</span>재생
+              </Button>
+              <button
+                className="m-0 rounded-full bg-transparent stroke-[1px] p-0 text-5xl"
+                onClick={() => toggleFavorite(item)}
+              >
+                {isFavorite(Number(id)) ? (
+                  <IoCheckmarkCircle />
+                ) : (
+                  <IoAddCircleOutline />
+                )}
+              </button>
+            </div>
           </div>
 
           <button
-            className="path-white m-spacingSm lg:m-spacingLg md:m-spacingMd absolute right-0 top-0 text-4xl"
+            className="path-white absolute right-0 top-0 m-spacingSm text-4xl md:m-spacingMd lg:m-spacingLg"
             onClick={onClose}
           >
             <IoMdCloseCircle />

--- a/src/contexts/FavoriteContext.tsx
+++ b/src/contexts/FavoriteContext.tsx
@@ -1,0 +1,111 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { FavoriteItem } from '@/types';
+import supabase from '@/supabaseClient';
+import { useAuth } from './AuthContext';
+
+interface FavoriteContextType {
+  favorites: FavoriteItem[];
+  isFavorite: (id: number) => boolean;
+  toggleFavorite: (item: FavoriteItem) => Promise<void>;
+  loading: boolean;
+}
+
+const FavoriteContext = createContext<FavoriteContextType | undefined>(
+  undefined,
+);
+
+export function FavoriteProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setFavorites([]);
+      return;
+    }
+
+    const fetchFavorites = async () => {
+      const { data, error } = await supabase
+        .from('favorites')
+        .select('*')
+        .eq('user_id', user.id);
+
+      if (error) {
+        console.error('Error fetching favorites:', error);
+      } else if (data) {
+        setFavorites(
+          data.map(item => ({
+            id: item.tmdb_id,
+            media_type: item.media_type,
+            title: item.title,
+            poster_path: item.poster_path,
+          })),
+        );
+      }
+      setLoading(false);
+    };
+
+    fetchFavorites();
+  }, [user]);
+
+  const isFavorite = (id: number) => {
+    return favorites.some(el => el.id === id);
+  };
+
+  const toggleFavorite = async (item: FavoriteItem) => {
+    if (!user) return;
+
+    if (isFavorite(item.id)) {
+      const { error } = await supabase
+        .from('favorites')
+        .delete()
+        .eq('user_id', user.id)
+        .eq('tmdb_id', item.id);
+
+      if (error) {
+        console.error('Error removing favorite:', error);
+      } else {
+        setFavorites(prev => prev.filter(fav => fav.id !== item.id));
+      }
+    } else {
+      const { error } = await supabase.from('favorites').insert([
+        {
+          user_id: user.id,
+          tmdb_id: item.id,
+          media_type: item.media_type,
+          title: item.title,
+          poster_path: item.poster_path,
+        },
+      ]);
+
+      if (error) {
+        console.error('Error adding favorite:', error);
+      } else {
+        setFavorites(prev => [...prev, item]);
+      }
+    }
+  };
+
+  return (
+    <FavoriteContext.Provider
+      value={{ favorites, isFavorite, toggleFavorite, loading }}
+    >
+      {children}
+    </FavoriteContext.Provider>
+  );
+}
+
+export function useFavorites() {
+  const context = useContext(FavoriteContext);
+  if (!context) {
+    throw new Error('useFavorites must be used within an FavoriteProvider');
+  }
+  return context;
+}

--- a/src/hooks/useDetailModal.ts
+++ b/src/hooks/useDetailModal.ts
@@ -1,0 +1,16 @@
+import { useSearchParams, useLocation, useNavigate } from 'react-router-dom';
+
+export function useDetailModal() {
+  const [searchParams] = useSearchParams();
+  const type = searchParams.get('type');
+  const id = searchParams.get('id');
+
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const closeModal = () => {
+    navigate(location.pathname);
+  };
+
+  return { type, id, closeModal };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 import { AuthProvider } from '@/contexts/AuthContext.tsx';
+import { FavoriteProvider } from '@/contexts/FavoriteContext.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
-      <App />
+      <FavoriteProvider>
+        <App />
+      </FavoriteProvider>
     </AuthProvider>
   </StrictMode>,
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,27 +1,16 @@
-import { useSearchParams, useLocation, useNavigate } from 'react-router-dom';
 import Banner from '@/components/Banner';
 import Sliders from '@/components/Sliders';
 import DetailModal from '@/components/detailModal/DetailModal';
+import { useDetailModal } from '@/hooks/useDetailModal';
 
 export default function Home() {
-  const [searchParams] = useSearchParams();
-  const type = searchParams.get('type');
-  const id = searchParams.get('id');
-
-  const navigate = useNavigate();
-  const location = useLocation();
+  const { type, id, closeModal } = useDetailModal();
 
   return (
     <>
       <Banner />
       <Sliders />
-      {type && id && (
-        <DetailModal
-          type={type}
-          id={id}
-          onClose={() => navigate(location.pathname)}
-        />
-      )}
+      {type && id && <DetailModal type={type} id={id} onClose={closeModal} />}
     </>
   );
 }

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,0 +1,32 @@
+import { useFavorites } from '@/contexts/FavoriteContext';
+import MediaCard from '@/components/MediaCard';
+import DetailModal from '@/components/detailModal/DetailModal';
+import { useDetailModal } from '@/hooks/useDetailModal';
+
+export default function Mypage() {
+  const { type, id, closeModal } = useDetailModal();
+  const { favorites, loading } = useFavorites();
+
+  if (loading) return <p className="text-center text-white">불러오는 중...</p>;
+
+  if (favorites.length === 0)
+    return <p className="text-center text-gray-400">찜한 콘텐츠가 없습니다.</p>;
+
+  return (
+    <>
+      <h2>내가 찜한 리스트</h2>
+      <div className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+        {favorites.map(item => (
+          <MediaCard
+            key={item.id}
+            title={item.title}
+            imgSrc={item.poster_path || ''}
+            path={`?type=${item.media_type}&id=${item.id}`}
+          />
+        ))}
+      </div>
+
+      {type && id && <DetailModal type={type} id={id} onClose={closeModal} />}
+    </>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,10 @@ export interface SeasonItem {
   name: string;
   episodes: Episode[];
 }
+
+export interface FavoriteItem {
+  id: number;
+  media_type: string;
+  title: string;
+  poster_path: string | null;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

> 찜 추가/삭제 기능 구현
- FavoriteContext 전역 상태 생성
  - 사용자 찜 목록 fetch
  - toggleFavorite 함수 작성: 찜 추가/삭제 기능
- 상세 모달에 찜 버튼 추가: 추가/삭제 토글
- Mypage 컴포넌트 추가
  - /mypage로 라우트 설정
  - 사용자 찜 목록 렌더링 
> 리팩토링: useDetailModal 훅 분리
- 상세 모달 띄우는 로직을 커스텀 훅으로 분리하여 마이페이지에서도 재사용

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/1ca0485d-2a37-4361-930f-24096dd96921)
<img src="https://github.com/user-attachments/assets/594985fd-6c42-44e1-8f8d-21e31ee95863" width="300">
<img src="https://github.com/user-attachments/assets/831467be-261c-4b77-9bb4-f5044cb4b780" width="300">
![image](https://github.com/user-attachments/assets/a6025db3-bfe3-4efb-8a22-2df6e632e2e1)
