### PR TITLE
Feat/28 likes global state

### DIFF
--- a/src/components/detailModal/DetailModal.tsx
+++ b/src/components/detailModal/DetailModal.tsx
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import { IoMdCloseCircle } from 'react-icons/io';
-import { IoAddCircleOutline, IoCheckmarkCircle } from 'react-icons/io5';
-import type { MediaItem, FavoriteItem } from '@/types';
+import {
+  IoAddCircleOutline,
+  IoCheckmarkCircle,
+  IoHeartCircleOutline,
+  IoHeartCircle,
+} from 'react-icons/io5';
+import type { MediaItem, UserMediaItem } from '@/types';
 import useFetch from '@/hooks/useFetch';
 import { BASE_URL_ORIGIN } from '@/constants';
 import { parseMediaInfo } from '@/utils/parseMediaInfo';
@@ -9,6 +14,7 @@ import Button from '@/components/common/Button';
 import Recommendation from '@/components/detailModal/Recommendation';
 import Season from '@/components/detailModal/Season';
 import { useFavorites } from '@/contexts/FavoriteContext';
+import { useLikes } from '@/contexts/LikeContext';
 
 interface Props {
   type: string;
@@ -22,13 +28,14 @@ interface RecommendationsResponse {
 
 export default function DetailModal({ type, id, onClose }: Props) {
   const { isFavorite, toggleFavorite } = useFavorites();
+  const { isLiked, toggleLike } = useLikes();
   const { data, loading } = useFetch<MediaItem>(`${type}/${id}?language=ko`);
 
   const { data: recommendationData } = useFetch<RecommendationsResponse>(
     `${type}/${id}/recommendations?language=ko`,
   );
 
-  const item: FavoriteItem = {
+  const item: UserMediaItem = {
     id: Number(id),
     media_type: type,
     title: data?.title || data?.name || '',
@@ -77,6 +84,16 @@ export default function DetailModal({ type, id, onClose }: Props) {
                   <IoCheckmarkCircle />
                 ) : (
                   <IoAddCircleOutline />
+                )}
+              </button>
+              <button
+                className="m-0 rounded-full bg-transparent stroke-[1px] p-0 text-5xl"
+                onClick={() => toggleLike(item)}
+              >
+                {isLiked(Number(id)) ? (
+                  <IoHeartCircle />
+                ) : (
+                  <IoHeartCircleOutline />
                 )}
               </button>
             </div>

--- a/src/contexts/FavoriteContext.tsx
+++ b/src/contexts/FavoriteContext.tsx
@@ -1,13 +1,6 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  type ReactNode,
-} from 'react';
+import { createContext, useContext, type ReactNode } from 'react';
 import type { UserMediaItem } from '@/types';
-import supabase from '@/supabaseClient';
-import { useAuth } from './AuthContext';
+import useMediaList from '@/hooks/useMediaList';
 
 interface FavoriteContextType {
   favorites: UserMediaItem[];
@@ -21,77 +14,14 @@ const FavoriteContext = createContext<FavoriteContextType | undefined>(
 );
 
 export function FavoriteProvider({ children }: { children: ReactNode }) {
-  const { user } = useAuth();
-  const [favorites, setFavorites] = useState<UserMediaItem[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    if (!user) {
-      setFavorites([]);
-      return;
-    }
-
-    const fetchFavorites = async () => {
-      const { data, error } = await supabase
-        .from('favorites')
-        .select('*')
-        .eq('user_id', user.id);
-
-      if (error) {
-        console.error('Error fetching favorites:', error);
-      } else if (data) {
-        setFavorites(
-          data.map(item => ({
-            id: item.tmdb_id,
-            media_type: item.media_type,
-            title: item.title,
-            poster_path: item.poster_path,
-          })),
-        );
-      }
-      setLoading(false);
-    };
-
-    fetchFavorites();
-  }, [user]);
-
-  const isFavorite = (id: number) => {
-    return favorites.some(el => el.id === id);
-  };
-
-  const toggleFavorite = async (item: UserMediaItem) => {
-    if (!user) return;
-
-    if (isFavorite(item.id)) {
-      const { error } = await supabase
-        .from('favorites')
-        .delete()
-        .eq('user_id', user.id)
-        .eq('tmdb_id', item.id);
-
-      if (error) {
-        console.error('Error removing favorite:', error);
-      } else {
-        setFavorites(prev => prev.filter(fav => fav.id !== item.id));
-      }
-    } else {
-      const { error } = await supabase.from('favorites').insert([
-        {
-          user_id: user.id,
-          tmdb_id: item.id,
-          media_type: item.media_type,
-          title: item.title,
-          poster_path: item.poster_path,
-        },
-      ]);
-
-      if (error) {
-        console.error('Error adding favorite:', error);
-      } else {
-        setFavorites(prev => [...prev, item]);
-      }
-    }
-  };
+  const {
+    list: favorites,
+    loading,
+    isInList: isFavorite,
+    toggleItem: toggleFavorite,
+  } = useMediaList({
+    tableName: 'favorites',
+  });
 
   return (
     <FavoriteContext.Provider

--- a/src/contexts/FavoriteContext.tsx
+++ b/src/contexts/FavoriteContext.tsx
@@ -5,14 +5,14 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import type { FavoriteItem } from '@/types';
+import type { UserMediaItem } from '@/types';
 import supabase from '@/supabaseClient';
 import { useAuth } from './AuthContext';
 
 interface FavoriteContextType {
-  favorites: FavoriteItem[];
+  favorites: UserMediaItem[];
   isFavorite: (id: number) => boolean;
-  toggleFavorite: (item: FavoriteItem) => Promise<void>;
+  toggleFavorite: (item: UserMediaItem) => Promise<void>;
   loading: boolean;
 }
 
@@ -22,7 +22,7 @@ const FavoriteContext = createContext<FavoriteContextType | undefined>(
 
 export function FavoriteProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
-  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+  const [favorites, setFavorites] = useState<UserMediaItem[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -59,7 +59,7 @@ export function FavoriteProvider({ children }: { children: ReactNode }) {
     return favorites.some(el => el.id === id);
   };
 
-  const toggleFavorite = async (item: FavoriteItem) => {
+  const toggleFavorite = async (item: UserMediaItem) => {
     if (!user) return;
 
     if (isFavorite(item.id)) {

--- a/src/contexts/LikeContext.tsx
+++ b/src/contexts/LikeContext.tsx
@@ -1,13 +1,6 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  type ReactNode,
-} from 'react';
+import { createContext, useContext, type ReactNode } from 'react';
 import type { UserMediaItem } from '@/types';
-import supabase from '@/supabaseClient';
-import { useAuth } from './AuthContext';
+import useMediaList from '@/hooks/useMediaList';
 
 interface LikeContextType {
   likes: UserMediaItem[];
@@ -19,77 +12,14 @@ interface LikeContextType {
 const LikeContext = createContext<LikeContextType | undefined>(undefined);
 
 export function LikeProvider({ children }: { children: ReactNode }) {
-  const { user } = useAuth();
-  const [likes, setLikes] = useState<UserMediaItem[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    if (!user) {
-      setLikes([]);
-      return;
-    }
-
-    const fetchLikes = async () => {
-      const { data, error } = await supabase
-        .from('likes')
-        .select('*')
-        .eq('user_id', user.id);
-
-      if (error) {
-        console.error('Error fetching likes:', error);
-      } else if (data) {
-        setLikes(
-          data.map(item => ({
-            id: item.tmdb_id,
-            media_type: item.media_type,
-            title: item.title,
-            poster_path: item.poster_path,
-          })),
-        );
-      }
-      setLoading(false);
-    };
-
-    fetchLikes();
-  }, [user]);
-
-  const isLiked = (id: number) => {
-    return likes.some(el => el.id === id);
-  };
-
-  const toggleLike = async (item: UserMediaItem) => {
-    if (!user) return;
-
-    if (isLiked(item.id)) {
-      const { error } = await supabase
-        .from('likes')
-        .delete()
-        .eq('user_id', user.id)
-        .eq('tmdb_id', item.id);
-
-      if (error) {
-        console.error('Error removing like:', error);
-      } else {
-        setLikes(prev => prev.filter(fav => fav.id !== item.id));
-      }
-    } else {
-      const { error } = await supabase.from('likes').insert([
-        {
-          user_id: user.id,
-          tmdb_id: item.id,
-          media_type: item.media_type,
-          title: item.title,
-          poster_path: item.poster_path,
-        },
-      ]);
-
-      if (error) {
-        console.error('Error adding like:', error);
-      } else {
-        setLikes(prev => [...prev, item]);
-      }
-    }
-  };
+  const {
+    list: likes,
+    loading,
+    isInList: isLiked,
+    toggleItem: toggleLike,
+  } = useMediaList({
+    tableName: 'likes',
+  });
 
   return (
     <LikeContext.Provider value={{ likes, isLiked, toggleLike, loading }}>

--- a/src/contexts/LikeContext.tsx
+++ b/src/contexts/LikeContext.tsx
@@ -1,0 +1,107 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { FavoriteItem } from '@/types';
+import supabase from '@/supabaseClient';
+import { useAuth } from './AuthContext';
+
+interface LikeContextType {
+  likes: FavoriteItem[];
+  isLiked: (id: number) => boolean;
+  toggleLike: (item: FavoriteItem) => Promise<void>;
+  loading: boolean;
+}
+
+const LikeContext = createContext<LikeContextType | undefined>(undefined);
+
+export function LikeProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const [likes, setLikes] = useState<FavoriteItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setLikes([]);
+      return;
+    }
+
+    const fetchLikes = async () => {
+      const { data, error } = await supabase
+        .from('likes')
+        .select('*')
+        .eq('user_id', user.id);
+
+      if (error) {
+        console.error('Error fetching likes:', error);
+      } else if (data) {
+        setLikes(
+          data.map(item => ({
+            id: item.tmdb_id,
+            media_type: item.media_type,
+            title: item.title,
+            poster_path: item.poster_path,
+          })),
+        );
+      }
+      setLoading(false);
+    };
+
+    fetchLikes();
+  }, [user]);
+
+  const isLiked = (id: number) => {
+    return likes.some(el => el.id === id);
+  };
+
+  const toggleLike = async (item: FavoriteItem) => {
+    if (!user) return;
+
+    if (isLiked(item.id)) {
+      const { error } = await supabase
+        .from('likes')
+        .delete()
+        .eq('user_id', user.id)
+        .eq('tmdb_id', item.id);
+
+      if (error) {
+        console.error('Error removing like:', error);
+      } else {
+        setLikes(prev => prev.filter(fav => fav.id !== item.id));
+      }
+    } else {
+      const { error } = await supabase.from('likes').insert([
+        {
+          user_id: user.id,
+          tmdb_id: item.id,
+          media_type: item.media_type,
+          title: item.title,
+          poster_path: item.poster_path,
+        },
+      ]);
+
+      if (error) {
+        console.error('Error adding like:', error);
+      } else {
+        setLikes(prev => [...prev, item]);
+      }
+    }
+  };
+
+  return (
+    <LikeContext.Provider value={{ likes, isLiked, toggleLike, loading }}>
+      {children}
+    </LikeContext.Provider>
+  );
+}
+
+export function useLikes() {
+  const context = useContext(LikeContext);
+  if (!context) {
+    throw new Error('useLikes must be used within an LikeProvider');
+  }
+  return context;
+}

--- a/src/contexts/LikeContext.tsx
+++ b/src/contexts/LikeContext.tsx
@@ -5,14 +5,14 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import type { FavoriteItem } from '@/types';
+import type { UserMediaItem } from '@/types';
 import supabase from '@/supabaseClient';
 import { useAuth } from './AuthContext';
 
 interface LikeContextType {
-  likes: FavoriteItem[];
+  likes: UserMediaItem[];
   isLiked: (id: number) => boolean;
-  toggleLike: (item: FavoriteItem) => Promise<void>;
+  toggleLike: (item: UserMediaItem) => Promise<void>;
   loading: boolean;
 }
 
@@ -20,7 +20,7 @@ const LikeContext = createContext<LikeContextType | undefined>(undefined);
 
 export function LikeProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
-  const [likes, setLikes] = useState<FavoriteItem[]>([]);
+  const [likes, setLikes] = useState<UserMediaItem[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -57,7 +57,7 @@ export function LikeProvider({ children }: { children: ReactNode }) {
     return likes.some(el => el.id === id);
   };
 
-  const toggleLike = async (item: FavoriteItem) => {
+  const toggleLike = async (item: UserMediaItem) => {
     if (!user) return;
 
     if (isLiked(item.id)) {

--- a/src/hooks/useMediaList.ts
+++ b/src/hooks/useMediaList.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import type { UserMediaItem } from '@/types';
+import { useAuth } from '@/contexts/AuthContext';
+import supabase from '@/supabaseClient';
+
+export default function useMediaList({
+  tableName,
+}: {
+  tableName: 'favorites' | 'likes';
+}) {
+  const { user } = useAuth();
+  const [list, setList] = useState<UserMediaItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setList([]);
+      return;
+    }
+
+    const fetchList = async () => {
+      const { data, error } = await supabase
+        .from(tableName)
+        .select('*')
+        .eq('user_id', user.id);
+
+      if (error) {
+        console.error(`Error fetching ${tableName}:`, error);
+      } else if (data) {
+        setList(
+          data.map(item => ({
+            id: item.tmdb_id,
+            media_type: item.media_type,
+            title: item.title,
+            poster_path: item.poster_path,
+          })),
+        );
+      }
+      setLoading(false);
+    };
+
+    fetchList();
+  }, [user]);
+
+  const isInList = (id: number) => {
+    return list.some(el => el.id === id);
+  };
+
+  const toggleItem = async (item: UserMediaItem) => {
+    if (!user) return;
+
+    if (isInList(item.id)) {
+      const { error } = await supabase
+        .from(tableName)
+        .delete()
+        .eq('user_id', user.id)
+        .eq('tmdb_id', item.id);
+
+      if (error) {
+        console.error(`Error removing item from ${tableName}:`, error);
+      } else {
+        setList(prev => prev.filter(el => el.id !== item.id));
+      }
+    } else {
+      const { error } = await supabase.from(tableName).insert([
+        {
+          user_id: user.id,
+          tmdb_id: item.id,
+          media_type: item.media_type,
+          title: item.title,
+          poster_path: item.poster_path,
+        },
+      ]);
+
+      if (error) {
+        console.error(`Error adding item to ${tableName}:`, error);
+      } else {
+        setList(prev => [...prev, item]);
+      }
+    }
+  };
+
+  return { list, loading, isInList, toggleItem };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,12 +4,15 @@ import './index.css';
 import App from './App.tsx';
 import { AuthProvider } from '@/contexts/AuthContext.tsx';
 import { FavoriteProvider } from '@/contexts/FavoriteContext.tsx';
+import { LikeProvider } from './contexts/LikeContext.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
       <FavoriteProvider>
-        <App />
+        <LikeProvider>
+          <App />
+        </LikeProvider>
       </FavoriteProvider>
     </AuthProvider>
   </StrictMode>,

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -2,21 +2,30 @@ import { useFavorites } from '@/contexts/FavoriteContext';
 import MediaCard from '@/components/MediaCard';
 import DetailModal from '@/components/detailModal/DetailModal';
 import { useDetailModal } from '@/hooks/useDetailModal';
+import { useLikes } from '@/contexts/LikeContext';
 
 export default function Mypage() {
   const { type, id, closeModal } = useDetailModal();
-  const { favorites, loading } = useFavorites();
-
-  if (loading) return <p className="text-center text-white">불러오는 중...</p>;
-
-  if (favorites.length === 0)
-    return <p className="text-center text-gray-400">찜한 콘텐츠가 없습니다.</p>;
+  const { favorites } = useFavorites();
+  const { likes } = useLikes();
 
   return (
     <>
       <h2>내가 찜한 리스트</h2>
       <div className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
         {favorites.map(item => (
+          <MediaCard
+            key={item.id}
+            title={item.title}
+            imgSrc={item.poster_path || ''}
+            path={`?type=${item.media_type}&id=${item.id}`}
+          />
+        ))}
+      </div>
+
+      <h2>마음에 들어 하신 시리즈와 영화</h2>
+      <div className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+        {likes.map(item => (
           <MediaCard
             key={item.id}
             title={item.title}

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,3 +46,10 @@ export interface FavoriteItem {
   title: string;
   poster_path: string | null;
 }
+
+export interface LikeItem {
+  id: number;
+  media_type: string;
+  title: string;
+  poster_path: string | null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,14 +40,7 @@ export interface SeasonItem {
   episodes: Episode[];
 }
 
-export interface FavoriteItem {
-  id: number;
-  media_type: string;
-  title: string;
-  poster_path: string | null;
-}
-
-export interface LikeItem {
+export interface UserMediaItem {
   id: number;
   media_type: string;
   title: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28 

## 📝작업 내용

> 좋아요 추가/삭제 기능 구현
- LikeContext 전역 상태 생성
- 상세 모달에 좋아요 버튼 추가: 추가/삭제 토글
- Mypage 컴포넌트에서 사용자 좋아요 목록 렌더링
> 리팩토링: FavoriteContext와 LikeContext 중복 로직을 useMediaList 커스텀 훅으로 분리
- supabase의 테이블 이름(favorites 또는 likes) 인자로 받아 테이블 조회, 추가, 삭제, 확인 등 공통 로직 처리

## 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/4619dab1-a299-4ee5-9f8a-dce87bfe2527" width="300">
<img src="https://github.com/user-attachments/assets/2d98f09f-0e38-42f7-8783-433fddbf4b55" width="300">

![image](https://github.com/user-attachments/assets/c16dcf29-1733-4196-bc48-3152e9403dd9)
