### PR TITLE
Fix/35 search to mypage

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,10 +1,16 @@
 import { Outlet } from 'react-router-dom';
 import NavBar from '@/components/NavBar';
+import useSearchRouting from '@/hooks/useSearchRouting';
 
 function Layout() {
+  const { inputDebounce, setInputDebounce } = useSearchRouting();
+
   return (
     <>
-      <NavBar />
+      <NavBar
+        inputDebounce={inputDebounce}
+        setInputDebounce={setInputDebounce}
+      />
       <Outlet />
     </>
   );

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,18 +2,21 @@ import { useState, useRef, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { IoSearchSharp } from 'react-icons/io5';
 import useScroll from '@/hooks/useScroll';
-import useSearchRouting from '@/hooks/useSearchRouting';
 import { useAuth } from '@/contexts/AuthContext';
 import UserIcon from '@/components/UserIcon';
 
-export default function NavBar() {
+interface NavBarProps {
+  inputDebounce: string;
+  setInputDebounce: (value: string) => void;
+}
+
+export default function NavBar({ inputDebounce, setInputDebounce }: NavBarProps) {
   const [isInputVisible, setIsInputVisible] = useState<boolean>(false);
   const location = useLocation();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { user } = useAuth();
 
-  const { inputDebounce, setInputDebounce } = useSearchRouting();
   const isScrolled = useScroll();
 
   useEffect(() => {
@@ -52,7 +55,7 @@ export default function NavBar() {
         </div>
 
         {user ? (
-          <UserIcon />
+          <UserIcon setInputDebounce={setInputDebounce} />
         ) : (
           <Link to="/login">
             <button>로그인</button>

--- a/src/components/UserIcon.tsx
+++ b/src/components/UserIcon.tsx
@@ -3,7 +3,11 @@ import { FaUserCircle } from 'react-icons/fa';
 import { useAuth } from '@/contexts/AuthContext';
 import useLogout from '@/hooks/auth/useLogout';
 
-export default function UserIcon() {
+interface UserIconProps {
+  setInputDebounce: (value: string) => void;
+}
+
+export default function UserIcon({ setInputDebounce }: UserIconProps) {
   const { user } = useAuth();
   const userIcon = user?.user_metadata.avatar_url;
 
@@ -22,7 +26,9 @@ export default function UserIcon() {
       <div className="absolute right-0 top-0 hidden w-max group-hover:block">
         <ul className="mt-10 flex flex-col gap-4 bg-[#000000c1] p-4 text-sm">
           <li className="hover:underline">
-            <Link to="/mypage">마이페이지</Link>
+            <Link to="/mypage" onClick={() => setInputDebounce('')}>
+              마이페이지
+            </Link>
           </li>
           <li className="hover:underline">
             <button onClick={handleLogout}>로그아웃</button>

--- a/src/hooks/useSearchRouting.ts
+++ b/src/hooks/useSearchRouting.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import useDebounce from '@/hooks/useDebounce';
 
@@ -7,13 +7,20 @@ export default function useSearchRouting() {
   const debouncedValue = useDebounce(inputDebounce);
   const navigate = useNavigate();
   const location = useLocation();
+  const prevPathRef = useRef<string>(location.pathname);
+
+  useEffect(() => {
+    if (location.pathname !== '/search') {
+      prevPathRef.current = location.pathname;
+    }
+  }, [location.pathname]);
 
   useEffect(() => {
     if (debouncedValue.trim()) {
       navigate(`/search?keyword=${debouncedValue}`);
       console.log('keyword: ', debouncedValue);
     } else if (location.pathname.startsWith('/search')) {
-      navigate('/');
+      navigate(prevPathRef.current);
     }
   }, [debouncedValue, location.pathname, navigate]);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #35 

## 기존 문제
- NavBar와 UserIcon이 각각 독립적인 검색어 상태를 가지고 있어 검색 페이지에서 마이페이지로 이동되지 않음
- 검색어를 지우면 무조건 홈(/)으로 이동

## 📝작업 내용
- useSearchRouting훅을 공통 부모인 Layout 컴포넌트로 이동시켜 상태를 중앙에서 관리하도록 변경
- 상태와 상태 변경 함수를 NavBar와 UserIcon에 props로 전달하여 동일한 상태를 공유하도록 수정
- useRef를 사용하여 이전 경로를 기억하고 검색어를 지우면 이전 경로로 이동하도록 수정
